### PR TITLE
:bug: fix Blob usage issues for FormData mock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1392,6 +1392,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "fetch-blob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/fetch-blob/-/fetch-blob-2.1.2.tgz",
+      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow==",
+      "dev": true
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.22.1",
     "esm": "^3.2.25",
+    "fetch-blob": "^2.1.2",
     "mocha": "^8.4.0",
     "rollup": "^2.47.0",
     "terser": "^5.7.0",

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -22,7 +22,7 @@ export function getBodyByteSize(body) {
 
 function getStringByteLength(string) {
   // Compute the byte length of the string (which is not the same as string.length)
-  return global.Blob ? new global.Blob(string).size : Buffer.byteLength(string);
+  return global.Blob ? new global.Blob([string], { type: 'text/plain' }).size : Buffer.byteLength(string);
 }
 
 // Disallowed request headers for setRequestHeader()

--- a/test/UtilsTest.js
+++ b/test/UtilsTest.js
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-
+import Blob from 'fetch-blob';
 import { getBodyByteSize } from '../src/Utils';
 
 class BlobMock {
@@ -50,6 +50,18 @@ describe('Utils', () => {
     });
 
     it('should return FormData byte size', () => {
+      const form = new FormData();
+      form.append('my_field', 'abcd');
+      form.append('my_emojis', '😂👍');
+      form.append('my_blob', new BlobMock(10));
+      assert.equal(getBodyByteSize(form), 4 + 8 + 10);
+      // there's no global.Blob under pure node
+      assert.equal(global.Blob, undefined);
+    });
+
+    it('should return FormData byte size with Blob available', () => {
+      // mock blob in browser
+      global.Blob = Blob;
       const form = new FormData();
       form.append('my_field', 'abcd');
       form.append('my_emojis', '😂👍');


### PR DESCRIPTION
**Please make sure to run the tests (including linter)**
# Tested including the extra test case.
![image](https://user-images.githubusercontent.com/16681599/179568513-b66ac00a-d919-481e-91c9-bb5817b950f3.png)

## Summary of proposed changes
*Short description*

## Issue
Fixes bugs for the issue mentioned #31 .
An error thrown is solved.

## Details
*Longer description if relevant*
we should use `new Blob([string], {type: 'text/plain'});` to create a Blob according to latest
[MDN document](https://developer.mozilla.org/en-US/docs/Web/API/Blob)

## How to test the changes
*Added tests, etc.*
An extra unit test case is added to check the browser-like circumstance.