### PR TITLE
Add MockXhrRequest to encapsulate MockXhr requests

### DIFF
--- a/src/Factories.ts
+++ b/src/Factories.ts
@@ -27,13 +27,6 @@ export function newMockXhr(): typeof MockXhr {
       // Call the local MockXhr subclass' onCreate hook on the new mock instance
       LocalMockXhr.onCreate?.(this);
     }
-
-    send(body: any) {
-      super.send(body);
-
-      // Call the local MockXhr subclass' onSend hook
-      this._callOnSend(LocalMockXhr.onSend);
-    }
   };
 }
 

--- a/src/HeadersContainer.ts
+++ b/src/HeadersContainer.ts
@@ -23,13 +23,16 @@ export default class HeadersContainer {
 
   /**
    * Reset the container to its empty state.
+   *
+   * @returns this
    */
   reset() {
     this._headers.clear();
+    return this;
   }
 
   /**
-   * @param name Header name (case-insensitive)
+   * @param name Header name (case insensitive)
    * @returns Header value or null
    */
   getHeader(name: string) {
@@ -71,6 +74,7 @@ export default class HeadersContainer {
    *
    * @param name Header name
    * @param value Header value
+   * @returns this
    */
   addHeader(name: string, value: string) {
     name = name.toUpperCase();
@@ -79,5 +83,6 @@ export default class HeadersContainer {
       value = `${currentValue}, ${value}`;
     }
     this._headers.set(name, value);
+    return this;
   }
 }

--- a/src/MockXhrRequest.ts
+++ b/src/MockXhrRequest.ts
@@ -1,0 +1,125 @@
+import RequestData from './RequestData';
+import { getBodyByteSize } from './Utils';
+
+import type { MockXhrResponseReceiver } from './MockXhrResponseReceiver';
+
+/**
+ * A request produced by MockXhr.send() and methods to respond to it.
+ *
+ * Each call to MockXhr.send() on an instance creates a new instance of MockXhrRequest. When there
+ * are multiple active MockXhrRequest instances for the same MockXhr instance, only the response to
+ * the last one is considered. Responses to previous MockXhrRequests are ignored.
+ */
+export default class MockXhrRequest {
+  constructor(
+    private readonly _requestData: RequestData,
+    private readonly _responseReceiver: MockXhrResponseReceiver
+  ) {}
+
+  get requestData() { return this._requestData; }
+
+  /**
+   * @returns Request headers container
+   */
+  get requestHeaders() { return this._requestData.requestHeaders; }
+
+  get method() { return this._requestData.method; }
+
+  get url() { return this._requestData.url; }
+
+  get body() { return this._requestData.body; }
+
+  get withCredentials() { return this._requestData.withCredentials; }
+
+  /**
+   * Note: this isn't completely accurate for a multipart/form-data encoded FormData request body.
+   * MockXhr not consider headers, encoding, and other factors that influence the request body size
+   * of non-mocked XMLHttpRequest. You can consider the value returned by this method as a floor
+   * value for the request body size. This can still be useful to simulate upload progress events.
+   *
+   * @returns Request body's total byte size
+   */
+  getRequestBodySize() {
+    return getBodyByteSize(this.body);
+  }
+
+  /**
+   * Fire a request upload progress event.
+   *
+   * @param transmitted Bytes transmitted
+   */
+  uploadProgress(transmitted: number) {
+    this._responseReceiver.uploadProgress(
+      this._requestData,
+      transmitted,
+      this.getRequestBodySize()
+    );
+  }
+
+  /**
+   * Complete response method that sets the response headers and body. Changes the request's
+   * readyState to DONE.
+   *
+   * @param status Response http status (default 200)
+   * @param headers Name-value headers (optional)
+   * @param body Response body (default null)
+   * @param statusText Response http status text (optional)
+   */
+  respond(
+    status?: number,
+    headers?: Record<string, string> | null,
+    body?: any,
+    statusText?: string
+  ) {
+    this.setResponseHeaders(status, headers, statusText);
+    this.setResponseBody(body);
+  }
+
+  /**
+   * Set the response headers. Changes the request's readyState to HEADERS_RECEIVED.
+   *
+   * @param status Response http status (default 200)
+   * @param headers Name-value headers (optional)
+   * @param statusText Response http status text (optional)
+   */
+  setResponseHeaders(
+    status?: number,
+    headers?: Record<string, string> | null,
+    statusText?: string
+  ) {
+    this._responseReceiver.setResponseHeaders(this._requestData, status, headers, statusText);
+  }
+
+  /**
+   * Fire a response progress event. Changes the request's readyState to LOADING.
+   *
+   * @param transmitted Transmitted bytes
+   * @param length Total bytes
+   */
+  downloadProgress(transmitted: number, length: number) {
+    this._responseReceiver.downloadProgress(this._requestData, transmitted, length);
+  }
+
+  /**
+   * Set the response body. Changes the request's readyState to DONE.
+   *
+   * @param body Response body (default null)
+   */
+  setResponseBody(body: any = null) {
+    this._responseReceiver.setResponseBody(this._requestData, body);
+  }
+
+  /**
+   * Simulate a network error. Changes the request's readyState to DONE.
+   */
+  setNetworkError() {
+    this._responseReceiver.setNetworkError(this._requestData);
+  }
+
+  /**
+   * Simulate a request timeout. Changes the request's readyState to DONE.
+   */
+  setRequestTimeout() {
+    this._responseReceiver.setRequestTimeout(this._requestData);
+  }
+}

--- a/src/MockXhrResponseReceiver.ts
+++ b/src/MockXhrResponseReceiver.ts
@@ -1,0 +1,23 @@
+import type RequestData from './RequestData';
+
+/**
+ * Methods for responding to MockXhr requests
+ */
+export interface MockXhrResponseReceiver {
+  uploadProgress(request: RequestData, transmitted: number, length: number) : void;
+
+  setResponseHeaders(
+    request: RequestData,
+    status?: number,
+    headers?: Record<string, string> | null,
+    statusText?: string
+  ) : void;
+
+  downloadProgress(request: RequestData, transmitted: number, length: number): void;
+
+  setResponseBody(request: RequestData, body: any): void;
+
+  setNetworkError(request: RequestData): void;
+
+  setRequestTimeout(request: RequestData): void;
+}

--- a/src/RequestData.ts
+++ b/src/RequestData.ts
@@ -1,0 +1,27 @@
+import HeadersContainer from './HeadersContainer';
+
+/**
+ * Request parameters from MockXhr.send()
+ */
+export default class RequestData {
+  constructor(
+    private readonly _requestHeaders: HeadersContainer,
+    private readonly _method: string,
+    private readonly _url: string,
+    private readonly _body: any = null,
+    private readonly _withCredentials: boolean = false
+  ) {}
+
+  /**
+   * @returns Request headers container
+   */
+  get requestHeaders() { return new HeadersContainer(this._requestHeaders); }
+
+  get method() { return this._method; }
+
+  get url() { return this._url; }
+
+  get body() { return this._body; }
+
+  get withCredentials() { return this._withCredentials; }
+}

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -73,7 +73,7 @@ export function isRequestMethodForbidden(method: string) {
 
 // Normalize method names as described in open()
 // https://xhr.spec.whatwg.org/#the-open()-method
-const upperCaseMethods = [
+export const upperCaseMethods = [
   'DELETE',
   'GET',
   'HEAD',

--- a/test/HeadersContainerTest.ts
+++ b/test/HeadersContainerTest.ts
@@ -39,7 +39,7 @@ describe('HeadersContainer', () => {
     assert.strictEqual(headers.getHeader('not-exists'), null);
   });
 
-  it('headers should be case-insensitive', () => {
+  it('headers should be case insensitive', () => {
     const headers = new HeadersContainer();
     headers.addHeader('header', '1');
     assert.strictEqual(headers.getHeader('HEADER'), '1');

--- a/test/MockXhrTest.ts
+++ b/test/MockXhrTest.ts
@@ -1,6 +1,10 @@
 import { assert } from 'chai';
 
+import HeadersContainer from '../src/HeadersContainer';
 import MockXhr from '../src/MockXhr';
+import MockXhrRequest from '../src/MockXhrRequest';
+import RequestData from '../src/RequestData';
+import { upperCaseMethods } from '../src/Utils';
 import XhrEventTarget from '../src/XhrEventTarget';
 import { XHR_PROGRESS_EVENT_NAMES } from '../src/XhrProgressEventsNames';
 
@@ -54,6 +58,14 @@ describe('MockXhr', () => {
     assert.strictEqual(xhr.responseText, '', 'empty xhr.responseText');
   }
 
+  function assertSameRequest(req1: RequestData, req2: RequestData) {
+    assert.strictEqual(req1.requestHeaders.getAll(), req2.requestHeaders.getAll(), 'headers');
+    assert.strictEqual(req1.method, req2.method, 'method');
+    assert.strictEqual(req1.url, req2.url, 'url');
+    assert.deepEqual(req1.body, req2.body, 'body');
+    assert.strictEqual(req1.withCredentials, req2.withCredentials, 'withCredentials');
+  }
+
   describe('states', () => {
     it('should have state constants', () => {
       assert.strictEqual(MockXhr.UNSENT, 0);
@@ -71,20 +83,11 @@ describe('MockXhr', () => {
 
   describe('request', () => {
     describe('open()', () => {
-      it('should record url and method', () => {
-        const xhr = new MockXhr();
-
-        xhr.open('get', '/url');
-
-        assert.strictEqual(xhr.method, 'GET', 'upper-case method');
-        assert.strictEqual(xhr.url, '/url');
-      });
-
       it('should change state', () => {
         const xhr = new MockXhr();
         const events = recordEvents(xhr);
 
-        xhr.open('get', '/url');
+        xhr.open('GET', '/url');
 
         assert.deepEqual(events, ['readystatechange(1)'], 'readystatechange fired');
       });
@@ -92,37 +95,64 @@ describe('MockXhr', () => {
       it('should be re-entrant', () => {
         const xhr = new MockXhr();
         const events = recordEvents(xhr);
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('GET', '/url');
+        xhr.open('POST', '/url2');
+        xhr.send();
 
-        xhr.open('get', '/url');
-        xhr.open('post', '/url2');
-
-        assert.strictEqual(xhr.method, 'POST', 'second method');
-        assert.strictEqual(xhr.url, '/url2', 'second url');
-        assert.strictEqual(xhr.readyState, MockXhr.OPENED);
-        assert.deepEqual(events, ['readystatechange(1)'], 'readystatechange fired');
+        return done.then((request) => {
+          assert.strictEqual(request.method, 'POST', 'second method');
+          assert.strictEqual(request.url, '/url2', 'second url');
+          assert.strictEqual(xhr.readyState, MockXhr.OPENED);
+          assert.deepEqual(events, [
+            'readystatechange(1)',
+            'loadstart(0,0,false)',
+          ], 'readystatechange fired');
+        });
       });
 
       it('should reject forbidden methods', () => {
         const xhr = new MockXhr();
-        const events = recordEvents(xhr);
-
         const tryMethod = (method: string) => {
           return () => { xhr.open(method, '/url'); };
         };
+        const events = recordEvents(xhr);
         assert.throws(tryMethod('CONNECT'), null, null, 'forbidden method throws');
         assert.throws(tryMethod('TRACE'), null, null, 'forbidden method throws');
         assert.throws(tryMethod('TRACK'), null, null, 'forbidden method throws');
         assert.lengthOf(events, 0, 'no events fired');
+      });
+
+      it('should normalize method names', () => {
+        const promises = upperCaseMethods.map((method) => {
+          const xhr = new MockXhr();
+          xhr.open(method.toLowerCase(), 'url');
+          const promise: Promise<MockXhrRequest> = new Promise((resolve) => {
+            xhr.onSend = resolve;
+          });
+          xhr.send();
+          return promise;
+        });
+
+        return Promise.all(promises).then((requests) => {
+          requests.forEach((request, i) => {
+            assert.strictEqual(request.method, upperCaseMethods[i]);
+          });
+        });
       });
     });
 
     describe('setRequestHeader()', () => {
       it('should record header value', () => {
         const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
-
         xhr.setRequestHeader('Head', '1');
-        assert.strictEqual(xhr.requestHeaders.getHeader('HEAD'), '1', 'header is case-insensitive');
+        xhr.send();
+
+        return done.then((request) => {
+          assert.strictEqual(request.requestHeaders.getHeader('HEAD'), '1', 'header is case insensitive');
+        });
       });
 
       it('should throw InvalidStateError if not opened', () => {
@@ -156,19 +186,32 @@ describe('MockXhr', () => {
       forbiddenHeaders.forEach((header) => {
         it(`should reject forbidden header ${header}`, () => {
           const xhr = new MockXhr();
+          const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
           xhr.open('GET', '/url');
           xhr.setRequestHeader(header, '1');
-          assert.strictEqual(
-            xhr.requestHeaders.getHeader(header),
-            null,
-            'Forbidden header not set'
-          );
+          xhr.send();
+
+          return done.then((request) => {
+            assert.strictEqual(
+              request.requestHeaders.getHeader(header),
+              null,
+              'Forbidden header not set'
+            );
+          });
         });
       });
     });
 
     describe('timeout attribute', function () {
-      this.slow(250);
+      this.slow(100);
+
+      function mockSetTimeout() {
+        const calls: [Function, number][] = [];
+        const mock = (handler: Function, timeout: number) => { calls.push([handler, timeout]); };
+        const saved = globalThis.setTimeout;
+        globalThis.setTimeout = mock as typeof global.setTimeout;
+        return { calls, restore: () => { globalThis.setTimeout = saved; } };
+      }
 
       it('can get and set its value', () => {
         const xhr = new MockXhr();
@@ -178,21 +221,22 @@ describe('MockXhr', () => {
         assert.strictEqual(xhr.timeout, timeout);
       });
 
-      it('will trigger a timeout if set before send()', (done) => {
+      it('will trigger a timeout if set before send()', () => {
         const xhr = new MockXhr();
+        const done = new Promise((resolve) => { xhr.addEventListener('timeout', resolve); });
         xhr.open('GET', '/url');
         const events = recordEvents(xhr);
         xhr.timeout = 1;
-        xhr.addEventListener('timeout', () => {
+        xhr.send();
+
+        return done.then(() => {
           assert.deepEqual(events, [
             'loadstart(0,0,false)',
             'readystatechange(4)',
             'timeout(0,0,false)',
+            'loadend(0,0,false)',
           ], 'fired events');
-          done();
         });
-
-        xhr.send();
       });
 
       it('will trigger a timeout if set after send()', (done) => {
@@ -203,91 +247,132 @@ describe('MockXhr', () => {
         xhr.addEventListener('timeout', () => { done(); });
       });
 
-      it('delay is measured relative to send()', (done) => {
+      it('measures timeout delay relative to send()', (done) => {
         const xhr = new MockXhr();
+        const delay = 100;
+
         xhr.open('GET', '/url');
         xhr.send();
 
-        const delay = 100;
         setTimeout(() => {
-          const setTimeoutAt = Date.now();
-          xhr.timeout = delay;
-          xhr.addEventListener('timeout', () => {
-            const actualDelay = Date.now() - setTimeoutAt;
-            assert.isBelow(actualDelay, delay, 'timeout delay relative to start of request');
-            done();
-          });
-        }, delay);
+          const { calls, restore } = mockSetTimeout();
+          try {
+            xhr.timeout = delay;
+          } finally {
+            restore();
+          }
+          const setTimeoutArg = calls[0][1];
+          assert.isTrue(setTimeoutArg <= delay - 20);
+          done();
+        }, 20);
       });
 
       it('has no effect when the response is sent fast enough', (done) => {
         const xhr = new MockXhr();
+        let gotTimeoutEvent = false;
+
+        xhr.onSend = (request) => { request.respond(); };
+        xhr.addEventListener('timeout', () => { gotTimeoutEvent = true; });
         xhr.open('GET', '/url');
         xhr.send();
-
-        let gotTimeoutEvent = false;
-        xhr.addEventListener('timeout', () => { gotTimeoutEvent = true; });
-        xhr.timeout = 40;
-
-        xhr.respond();
-
-        // Wait to make sure the timeout has no effect
-        setTimeout(() => {
-          assert.isFalse(gotTimeoutEvent, 'there should be no timeout event');
-          done();
-        }, 100);
-      });
-
-      it('can be cancelled', (done) => {
-        const xhr = new MockXhr();
-        xhr.open('GET', '/url');
-        xhr.send();
-
-        let gotTimeoutEvent = false;
-        xhr.addEventListener('timeout', () => { gotTimeoutEvent = true; });
-        xhr.timeout = 40;
-        Promise.resolve(true).then(() => { xhr.timeout = 0; });
-
-        // Wait to make sure the timeout has no effect
-        setTimeout(() => {
-          assert.isFalse(gotTimeoutEvent, 'there should be no timeout event');
-          done();
-        }, 100);
-      });
-
-      it('can be disabled per instance', (done) => {
-        const xhr = new MockXhr();
-        xhr.timeoutEnabled = false;
-        xhr.open('GET', '/url');
-        xhr.send();
-
-        let gotTimeoutEvent = false;
-        xhr.addEventListener('timeout', () => { gotTimeoutEvent = true; });
         xhr.timeout = 1;
 
         // Wait to make sure the timeout has no effect
         setTimeout(() => {
           assert.isFalse(gotTimeoutEvent, 'there should be no timeout event');
           done();
-        }, 40);
+        }, 20);
       });
 
-      it('can be disabled globally', (done) => {
+      it('can be cancelled', (done) => {
+        const xhr = new MockXhr();
+        let gotTimeoutEvent = false;
+
+        xhr.addEventListener('timeout', () => { gotTimeoutEvent = true; });
+        xhr.open('GET', '/url');
+        xhr.send();
+        xhr.timeout = 1;
+        Promise.resolve(true).then(() => { xhr.timeout = 0; });
+
+        // Wait to make sure the timeout has no effect
+        setTimeout(() => {
+          assert.isFalse(gotTimeoutEvent, 'there should be no timeout event');
+          done();
+        }, 20);
+      });
+
+      it('is cancelled by open()', (done) => {
+        const xhr = new MockXhr();
+        let gotTimeoutEvent = false;
+
+        xhr.addEventListener('timeout', () => { gotTimeoutEvent = true; });
+        xhr.open('GET', '/url');
+        xhr.send();
+        xhr.timeout = 1;
+        xhr.open('GET', '/url');
+
+        // Wait to make sure the timeout has no effect
+        setTimeout(() => {
+          assert.isFalse(gotTimeoutEvent, 'there should be no timeout event');
+          done();
+        }, 20);
+      });
+
+      it('can be disabled per instance', (done) => {
+        const xhr = new MockXhr();
+        let gotTimeoutEvent = false;
+
+        xhr.timeoutEnabled = false;
+        xhr.addEventListener('timeout', () => { gotTimeoutEvent = true; });
+        xhr.open('GET', '/url');
+        xhr.send();
+        xhr.timeout = 1;
+
+        // Wait to make sure the timeout has no effect
+        setTimeout(() => {
+          assert.isFalse(gotTimeoutEvent, 'there should be no timeout event');
+          done();
+        }, 20);
+      });
+
+      it('can be disabled on subclass', (done) => {
         try {
-          MockXhr.timeoutEnabled = false;
-          const xhr = new MockXhr();
+          class LocalMockXhr extends MockXhr {}
+          const xhr = new LocalMockXhr();
+          let gotTimeoutEvent = false;
+
+          LocalMockXhr.timeoutEnabled = false;
+          xhr.addEventListener('timeout', () => { gotTimeoutEvent = true; });
           xhr.open('GET', '/url');
           xhr.send();
-
-          let gotTimeoutEvent = false;
-          xhr.addEventListener('timeout', () => { gotTimeoutEvent = true; });
           xhr.timeout = 1;
 
           // Wait to make sure the timeout has no effect
           setTimeout(() => {
             assert.isFalse(gotTimeoutEvent, 'there should be no timeout event');
             done();
-          }, 40);
+          }, 20);
+        } finally {
+          MockXhr.timeoutEnabled = true;
+        }
+      });
+
+      it('can be disabled globally', (done) => {
+        try {
+          const xhr = new MockXhr();
+          let gotTimeoutEvent = false;
+
+          MockXhr.timeoutEnabled = false;
+          xhr.addEventListener('timeout', () => { gotTimeoutEvent = true; });
+          xhr.open('GET', '/url');
+          xhr.send();
+          xhr.timeout = 1;
+
+          // Wait to make sure the timeout has no effect
+          setTimeout(() => {
+            assert.isFalse(gotTimeoutEvent, 'there should be no timeout event');
+            done();
+          }, 20);
         } finally {
           MockXhr.timeoutEnabled = true;
         }
@@ -302,11 +387,15 @@ describe('MockXhr', () => {
 
       it('should throw if set when state is not unsent or opened or if the send() flag is set', () => {
         const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.send();
-        assert.throws(() => { xhr.withCredentials = true; });
-        xhr.respond();
-        assert.throws(() => { xhr.withCredentials = true; });
+
+        return done.then((request) => {
+          assert.throws(() => { xhr.withCredentials = true; });
+          request.respond();
+          assert.throws(() => { xhr.withCredentials = true; });
+        });
       });
 
       it('can get and set its value', () => {
@@ -322,66 +411,81 @@ describe('MockXhr', () => {
     });
 
     describe('send()', () => {
-      it('should record the request body', () => {
+      it('should capture RequestData', () => {
         const xhr = new MockXhr();
-        xhr.open('POST', '/url');
-        const body = {
-          body: 'body',
-        };
+        const requestData = new RequestData(
+          new HeadersContainer().addHeader('test', 'ok'),
+          'POST',
+          '/url',
+          { body: 'body' },
+          true
+        );
 
-        xhr.send(body);
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open(requestData.method, requestData.url);
+        xhr.setRequestHeader('test', 'ok');
+        xhr.withCredentials = requestData.withCredentials;
+        xhr.send(requestData.body);
 
-        assert.strictEqual(xhr.body, body, 'Recorded request body');
+        return done.then((request) => {
+          assertSameRequest(request.requestData, requestData);
+        });
       });
 
       it('should set Content-Type for string body', () => {
         const xhr = new MockXhr();
+        const body = 'body';
+
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('POST', '/url');
+        xhr.send(body);
 
-        xhr.send('body');
-
-        assert.strictEqual(
-          xhr.requestHeaders.getHeader('Content-Type'),
-          'text/plain;charset=UTF-8',
-          'Content-Type set'
-        );
+        return done.then((request) => {
+          assert.strictEqual(
+            request.requestHeaders.getHeader('Content-Type'),
+            'text/plain;charset=UTF-8',
+            'Content-Type set'
+          );
+        });
       });
 
       it('should use body mime type in request header', () => {
         const xhr = new MockXhr();
-        xhr.open('POST', '/url');
-        const body = {
-          type: 'image/jpeg',
-        };
+        const body = { type: 'image/jpeg' };
 
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('POST', '/url');
         xhr.send(body);
 
-        assert.strictEqual(
-          xhr.requestHeaders.getHeader('Content-Type'),
-          body.type,
-          'Content-Type set'
-        );
+        return done.then((request) => {
+          assert.strictEqual(
+            request.requestHeaders.getHeader('Content-Type'),
+            body.type,
+            'Content-Type set'
+          );
+        });
       });
 
       it('should not set Content-Type for null body', () => {
         const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
-
         xhr.send();
 
-        assert.strictEqual(xhr.body, null, 'Recorded null body');
-        assert.strictEqual(
-          xhr.requestHeaders.getHeader('Content-Type'),
-          null,
-          'Content-Type not set'
-        );
+        return done.then((request) => {
+          assert.strictEqual(request.body, null, 'Recorded null body');
+          assert.strictEqual(
+            request.requestHeaders.getHeader('Content-Type'),
+            null,
+            'Content-Type not set'
+          );
+        });
       });
 
       it('should fire loadstart events', () => {
         const xhr = new MockXhr();
         xhr.open('POST', '/url');
         const events = recordEvents(xhr);
-
         xhr.send('body');
 
         assert.deepEqual(events, ['loadstart(0,0,false)', 'upload.loadstart(0,4,true)'], 'fired events');
@@ -421,7 +525,6 @@ describe('MockXhr', () => {
         const xhr = new MockXhr();
         xhr.open('GET', '/url');
         const events = recordEvents(xhr);
-
         xhr.abort();
 
         assert.lengthOf(events, 0, 'no abort event');
@@ -433,7 +536,6 @@ describe('MockXhr', () => {
         xhr.open('GET', '/url');
         xhr.send();
         const events = recordEvents(xhr);
-
         xhr.abort();
 
         assert.deepEqual(events, [
@@ -447,53 +549,62 @@ describe('MockXhr', () => {
 
       it('should follow the steps for open()-send()-HEADERS_RECEIVED-abort() sequence', () => {
         const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.send();
-        xhr.setResponseHeaders();
-        const events = recordEvents(xhr);
 
-        xhr.abort();
+        return done.then((request) => {
+          request.setResponseHeaders();
+          const events = recordEvents(xhr);
+          xhr.abort();
 
-        assert.deepEqual(events, [
-          'readystatechange(4)',
-          'abort(0,0,false)',
-          'loadend(0,0,false)',
-        ], 'fired events');
-        assertNetworkErrorResponse(xhr);
-        assert.strictEqual(xhr.readyState, MockXhr.UNSENT, 'final state UNSENT');
+          assert.deepEqual(events, [
+            'readystatechange(4)',
+            'abort(0,0,false)',
+            'loadend(0,0,false)',
+          ], 'fired events');
+          assertNetworkErrorResponse(xhr);
+          assert.strictEqual(xhr.readyState, MockXhr.UNSENT, 'final state UNSENT');
+        });
       });
 
       it('should follow the steps for open()-send()-LOADING-abort() sequence', () => {
         const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.send();
-        xhr.setResponseHeaders();
-        xhr.downloadProgress(2, 8);
-        const events = recordEvents(xhr);
 
-        xhr.abort();
+        return done.then((request) => {
+          request.setResponseHeaders();
+          request.downloadProgress(2, 8);
+          const events = recordEvents(xhr);
+          xhr.abort();
 
-        assert.deepEqual(events, [
-          'readystatechange(4)',
-          'abort(0,0,false)',
-          'loadend(0,0,false)',
-        ], 'fired events');
-        assertNetworkErrorResponse(xhr);
-        assert.strictEqual(xhr.readyState, MockXhr.UNSENT, 'final state UNSENT');
+          assert.deepEqual(events, [
+            'readystatechange(4)',
+            'abort(0,0,false)',
+            'loadend(0,0,false)',
+          ], 'fired events');
+          assertNetworkErrorResponse(xhr);
+          assert.strictEqual(xhr.readyState, MockXhr.UNSENT, 'final state UNSENT');
+        });
       });
 
       it('should follow the steps for open()-send()-DONE-abort() sequence', () => {
         const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.send();
-        xhr.respond();
 
-        const events = recordEvents(xhr);
-        xhr.abort();
+        return done.then((request) => {
+          request.respond();
+          const events = recordEvents(xhr);
+          xhr.abort();
 
-        assert.deepEqual(events, [], 'no fired events');
-        assertNetworkErrorResponse(xhr);
-        assert.strictEqual(xhr.readyState, MockXhr.UNSENT, 'final state UNSENT');
+          assert.deepEqual(events, [], 'no fired events');
+          assertNetworkErrorResponse(xhr);
+          assert.strictEqual(xhr.readyState, MockXhr.UNSENT, 'final state UNSENT');
+        });
       });
 
       it('should fire upload abort for send(body)-abort() sequence', () => {
@@ -501,7 +612,6 @@ describe('MockXhr', () => {
         xhr.open('POST', '/url');
         const events = recordEvents(xhr);
         xhr.send('body');
-
         xhr.abort();
 
         assert.deepEqual(events, [
@@ -520,13 +630,13 @@ describe('MockXhr', () => {
           const xhr = new MockXhr();
 
           // Add onSend callbacks
-          let onSendCount = 0;
+          let onSendCalled = false;
           xhr.onSend = () => {
-            onSendCount += 1;
+            onSendCalled = true;
           };
-          let onSendXhrCount = 0;
+          let onSendXhrCalled = false;
           MockXhr.onSend = () => {
-            onSendXhrCount += 1;
+            onSendXhrCalled = true;
           };
 
           // Aborted send() during the loadstart event handler
@@ -538,8 +648,8 @@ describe('MockXhr', () => {
           xhr.send();
 
           return Promise.resolve(true).then(() => {
-            assert.strictEqual(onSendCount, 0, 'onSend() should not be called');
-            assert.strictEqual(onSendXhrCount, 0, 'onSend() should not be called');
+            assert.isFalse(onSendCalled, 'onSend() should not be called');
+            assert.isFalse(onSendXhrCalled, 'onSend() should not be called');
             assert.strictEqual(xhr.readyState, MockXhr.UNSENT, 'final state UNSENT');
           });
         } finally {
@@ -550,17 +660,17 @@ describe('MockXhr', () => {
       it('should handle nested open() during abort()', () => {
         const xhr = new MockXhr();
         const states: number[] = [];
-        let abortFlag = false;
+        let doAbort = false;
         xhr.onreadystatechange = () => {
           states.push(xhr.readyState);
-          if (abortFlag) {
+          if (doAbort) {
             xhr.open('GET', '/url');
           }
         };
 
         xhr.open('GET', '/url');
         xhr.send();
-        abortFlag = true;
+        doAbort = true;
         xhr.abort();
 
         assert.deepEqual(states, [MockXhr.OPENED, MockXhr.DONE, MockXhr.OPENED]);
@@ -569,11 +679,11 @@ describe('MockXhr', () => {
       it('should handle nested open()-send() during abort()', () => {
         const xhr = new MockXhr();
         const states: number[] = [];
-        let abortFlag = false;
+        let doAbort = false;
         xhr.onreadystatechange = () => {
           states.push(xhr.readyState);
-          if (abortFlag) {
-            abortFlag = false;
+          if (doAbort) {
+            doAbort = false;
             xhr.open('GET', '/url');
             xhr.send();
           }
@@ -581,7 +691,7 @@ describe('MockXhr', () => {
 
         xhr.open('GET', '/url');
         xhr.send();
-        abortFlag = true;
+        doAbort = true;
         xhr.abort();
 
         assert.deepEqual(states, [MockXhr.OPENED, MockXhr.DONE, MockXhr.OPENED]);
@@ -605,13 +715,17 @@ describe('MockXhr', () => {
     describe('overrideMimeType()', () => {
       it('should throw if set when state is loading or done', () => {
         const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.send();
-        xhr.setResponseHeaders();
-        xhr.downloadProgress(0, 4);
-        assert.throws(() => { xhr.overrideMimeType('text/plain'); });
-        xhr.setResponseBody('body');
-        assert.throws(() => { xhr.overrideMimeType('text/plain'); });
+
+        return done.then((request) => {
+          request.setResponseHeaders();
+          request.downloadProgress(0, 4);
+          assert.throws(() => { xhr.overrideMimeType('text/plain'); });
+          request.setResponseBody('body');
+          assert.throws(() => { xhr.overrideMimeType('text/plain'); });
+        });
       });
     });
 
@@ -623,13 +737,17 @@ describe('MockXhr', () => {
 
       it('should throw if set when state is loading or done', () => {
         const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.send();
-        xhr.setResponseHeaders();
-        xhr.downloadProgress(0, 4);
-        assert.throws(() => { xhr.responseType = 'text'; });
-        xhr.setResponseBody('body');
-        assert.throws(() => { xhr.responseType = 'text'; });
+
+        return done.then((request) => {
+          request.setResponseHeaders();
+          request.downloadProgress(0, 4);
+          assert.throws(() => { xhr.responseType = 'text'; });
+          request.setResponseBody('body');
+          assert.throws(() => { xhr.responseType = 'text'; });
+        });
       });
 
       validResponseTypes.forEach((value) => {
@@ -642,6 +760,7 @@ describe('MockXhr', () => {
 
       it('should ignore invalid values', () => {
         const xhr = new MockXhr();
+
         // @ts-ignore
         xhr.responseType = 'value';
         assert.strictEqual(xhr.responseType, '', 'responseType was not set');
@@ -654,18 +773,24 @@ describe('MockXhr', () => {
         assert.strictEqual(xhr.response, '', 'initial value');
       });
 
-      it('should return the empty string before loading with text responseType', () => {
+      it('should return the empty string before loading state with text responseType', () => {
         const xhr = new MockXhr();
         xhr.open('GET', '/url');
-        assert.strictEqual(xhr.response, '', 'empty string before loading');
+        assert.strictEqual(xhr.response, '', 'empty string before loading state');
       });
 
       it('should return the text response with text responseType', () => {
         const xhr = new MockXhr();
+        const body = 'body';
+
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.send();
-        xhr.setResponseBody('body');
-        assert.strictEqual(xhr.response, 'body', 'text response');
+
+        return done.then((request) => {
+          request.setResponseBody(body);
+          assert.strictEqual(xhr.response, 'body', 'text response');
+        });
       });
 
       it('should return null if state is not done with non-text responseType', () => {
@@ -680,60 +805,87 @@ describe('MockXhr', () => {
         const data = value === '' || value === 'text' ? ['empty string', ''] : ['null', null];
         it(`should return ${data[0]} with null body and "${value}" responseType`, () => {
           const xhr = new MockXhr();
+          const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
           xhr.open('GET', '/url');
           xhr.responseType = value;
           xhr.send();
-          xhr.respond();
-          assert.strictEqual(xhr.response, data[1], 'responseType was set');
+
+          return done.then((request) => {
+            request.respond();
+            assert.strictEqual(xhr.response, data[1], 'responseType was set');
+          });
         });
       });
 
       it('should return the response body as-is with arraybuffer responseType', () => {
         const xhr = new MockXhr();
+
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.responseType = 'arraybuffer';
         xhr.send();
-        const body = { body: 'test' };
-        xhr.setResponseBody(body);
-        assert.strictEqual(xhr.response, body, 'passthrough response');
+
+        return done.then((request) => {
+          const body = { body: 'test' };
+          request.setResponseBody(body);
+          assert.strictEqual(xhr.response, body, 'passthrough response');
+        });
       });
 
       it('should return the response body as-is with blob responseType', () => {
         const xhr = new MockXhr();
+
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.responseType = 'blob';
         xhr.send();
-        const body = { body: 'test' };
-        xhr.setResponseBody(body);
-        assert.strictEqual(xhr.response, body, 'passthrough response');
+
+        return done.then((request) => {
+          const body = { body: 'test' };
+          request.setResponseBody(body);
+          assert.strictEqual(xhr.response, body, 'passthrough response');
+        });
       });
 
       it('should return the response body as-is with document responseType', () => {
         const xhr = new MockXhr();
+
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.responseType = 'document';
         xhr.send();
-        const body = { body: 'test' };
-        xhr.setResponseBody(body);
-        assert.strictEqual(xhr.response, body, 'passthrough response');
+
+        return done.then((request) => {
+          const body = { body: 'test' };
+          request.setResponseBody(body);
+          assert.strictEqual(xhr.response, body, 'passthrough response');
+        });
       });
 
       it('should return the json response with json responseType', () => {
         const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.responseType = 'json';
         xhr.send();
-        xhr.setResponseBody('{"a": 1}');
-        assert.deepEqual(xhr.response, { a: 1 }, 'json response');
+
+        return done.then((request) => {
+          request.setResponseBody('{"a": 1}');
+          assert.deepEqual(xhr.response, { a: 1 }, 'json response');
+        });
       });
 
       it('should return null for invalid json response with json responseType', () => {
         const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.responseType = 'json';
         xhr.send();
-        xhr.setResponseBody('{');
-        assert.strictEqual(xhr.response, null, 'null response');
+
+        return done.then((request) => {
+          request.setResponseBody('{');
+          assert.strictEqual(xhr.response, null, 'null response');
+        });
       });
     });
 
@@ -745,11 +897,15 @@ describe('MockXhr', () => {
 
       it('should throw if accessed with non-text responseType', () => {
         const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.responseType = 'json';
         xhr.send();
-        xhr.respond();
-        assert.throws(() => { return xhr.responseText; });
+
+        return done.then((request) => {
+          request.respond();
+          assert.throws(() => { return xhr.responseText; });
+        });
       });
 
       it('should return the empty string before loading', () => {
@@ -760,10 +916,16 @@ describe('MockXhr', () => {
 
       it('should return the text response', () => {
         const xhr = new MockXhr();
+
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.send();
-        xhr.setResponseBody('body');
-        assert.strictEqual(xhr.responseText, 'body', 'text response');
+
+        return done.then((request) => {
+          const body = 'body';
+          request.setResponseBody(body);
+          assert.strictEqual(xhr.responseText, body, 'text response');
+        });
       });
     });
 
@@ -786,534 +948,564 @@ describe('MockXhr', () => {
         assert.strictEqual(xhr.responseXML, null, 'state is not done');
       });
 
-      it('should return the response body as-is with document responseType', () => {
+      it('should return the response body as-is with the document responseType', () => {
         const xhr = new MockXhr();
-        xhr.open('GET', '/url');
         xhr.responseType = 'document';
+
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('GET', '/url');
         xhr.send();
-        const body = { body: 'test' };
-        xhr.setResponseBody(body);
-        assert.strictEqual(xhr.responseXML, body, 'passthrough response');
+
+        return done.then((request) => {
+          const body = { body: 'test' };
+          request.setResponseBody(body);
+          assert.strictEqual(xhr.responseXML, body, 'passthrough response');
+        });
       });
     });
   });
 
-  describe('Hooks', () => {
-    it('should call MockXhr.onCreate()', () => {
-      try {
-        let onCreateCount = 0;
-        MockXhr.onCreate = () => {
-          onCreateCount += 1;
-        };
+  describe('Lifecycle hooks', () => {
+    describe('onCreate()', () => {
+      it('should be called', () => {
+        try {
+          const args: MockXhr[] = [];
 
-        const xhr = new MockXhr();
+          MockXhr.onCreate = (arg) => {
+            args.push(arg);
+          };
 
-        assert.instanceOf(xhr, MockXhr);
-        assert.strictEqual(onCreateCount, 1, 'onCreate() called');
-      } finally {
-        delete MockXhr.onCreate;
-      }
-    });
+          const xhr = new MockXhr();
 
-    it('should call MockXhr.onSend()', () => {
-      try {
-        const xhr = new MockXhr();
-
-        // Add a "global" onSend callback
-        let onSendContext: any;
-        let onSendArg: any;
-        MockXhr.onSend = function onSend(arg) {
-          onSendContext = this;
-          onSendArg = arg;
-        };
-
-        xhr.open('GET', '/url');
-        xhr.send();
-
-        return Promise.resolve(true).then(() => {
-          assert.strictEqual(onSendContext, xhr, 'context');
-          assert.strictEqual(onSendArg, xhr, 'argument');
-        });
-      } finally {
-        delete MockXhr.onSend;
-      }
-    });
-
-    it('should call xhr.onSend() method', () => {
-      const xhr = new MockXhr();
-
-      // Add a request-local onSend callback
-      let onSendContext: any;
-      let onSendArg: any;
-      xhr.onSend = function onSend(arg) {
-        onSendContext = this;
-        onSendArg = arg;
-      };
-
-      xhr.open('GET', '/url');
-      xhr.send();
-
-      return Promise.resolve(true).then(() => {
-        assert.strictEqual(onSendContext, xhr, 'context');
-        assert.strictEqual(onSendArg, xhr, 'argument');
+          assert.instanceOf(xhr, MockXhr);
+          assert.deepEqual(args, [xhr], 'correct parameters for callbacks');
+        } finally {
+          delete MockXhr.onCreate;
+        }
       });
     });
 
-    it('should call MockXhr.onSend() and xhr.onSend()', () => {
-      try {
+    describe('onSend()', () => {
+      it('should be called in order', () => {
+        try {
+          class LocalMockXhr extends MockXhr {}
+          const xhr = new LocalMockXhr();
+          const calls: string[] = [];
+          const thisValues: MockXhrRequest[] = [];
+          const args: MockXhrRequest[] = [];
+
+          const done = new Promise((resolve) => {
+            MockXhr.onSend = function onSend(arg) {
+              calls.push('global');
+              thisValues.push(this);
+              args.push(arg);
+            };
+
+            LocalMockXhr.onSend = function onSendLocal(arg) {
+              calls.push('subclass');
+              thisValues.push(this);
+              args.push(arg);
+            };
+
+            xhr.onSend = function onSendXhr(arg) {
+              calls.push('xhr');
+              thisValues.push(this);
+              args.push(arg);
+              resolve(true);
+            };
+          });
+          xhr.open('GET', '/url');
+          xhr.send();
+
+          return done.then(() => {
+            const req = xhr.currentRequest;
+            assert.instanceOf(req, MockXhrRequest);
+            assert.deepEqual(calls, ['global', 'subclass', 'xhr'], 'hooks called in the right order');
+            assert.deepEqual(thisValues, [req, req, req], 'correct contexts for callbacks');
+            assert.deepEqual(args, [req, req, req], 'correct parameters for callbacks');
+          });
+        } finally {
+          delete MockXhr.onSend;
+        }
+      });
+
+      it('should call all callback stages even if they are the same function', () => {
+        try {
+          class LocalMockXhr extends MockXhr {}
+          const xhr = new LocalMockXhr();
+          let callCount = 0;
+
+          const done = new Promise((resolve) => {
+            const onSend = () => {
+              if (++callCount === 3) {
+                resolve(true);
+              }
+            };
+            MockXhr.onSend = onSend;
+            LocalMockXhr.onSend = onSend;
+            xhr.onSend = onSend;
+          });
+          xhr.open('GET', '/url');
+          xhr.send();
+
+          return done.then(() => {
+            assert.strictEqual(callCount, 3);
+          });
+        } finally {
+          delete MockXhr.onSend;
+        }
+      });
+
+      it('should defensively copy the callback', () => {
+        try {
+          class LocalMockXhr extends MockXhr {}
+          const xhr = new LocalMockXhr();
+          const calls: string[] = [];
+
+          const done = new Promise((resolve) => {
+            MockXhr.onSend = () => { calls.push('global'); };
+            LocalMockXhr.onSend = () => { calls.push('subclass'); };
+            xhr.onSend = () => { calls.push('xhr'); resolve(true); };
+          });
+          xhr.open('GET', '/url');
+          xhr.send();
+          delete MockXhr.onSend;
+          delete LocalMockXhr.onSend;
+          delete xhr.onSend;
+
+          return done.then(() => {
+            assert.deepEqual(calls, ['global', 'subclass', 'xhr'], 'hooks called in the right order');
+          });
+        } finally {
+          delete MockXhr.onSend;
+        }
+      });
+
+      it('should be called for each send() and have versioned requests', () => {
         const xhr = new MockXhr();
+        const requests: RequestData[] = [];
 
-        // Add onSend callbacks
-        let onSendCount = 0;
-        MockXhr.onSend = () => { onSendCount += 1; };
-        let onSendXhrCount = 0;
-        xhr.onSend = () => { onSendXhrCount += 1; };
-
-        xhr.open('GET', '/url');
+        let status = 200;
+        xhr.onSend = (request) => {
+          requests.push(request.requestData);
+          request.respond(status++);
+        };
+        xhr.open('GET', '/url1');
+        xhr.setRequestHeader('header1', 'val1');
         xhr.send();
+        xhr.open('POST', '/url2');
+        xhr.setRequestHeader('header2', 'val2');
+        xhr.send({ body: 1 });
 
         return Promise.resolve(true).then(() => {
-          assert.strictEqual(onSendCount, 1, 'called "global" onSend callback');
-          assert.strictEqual(onSendXhrCount, 1, 'called request-local onSend callback');
+          assertSameRequest(requests[0], new RequestData(
+            new HeadersContainer().addHeader('header1', 'val1'),
+            'GET',
+            '/url1'
+          ));
+          assertSameRequest(requests[1], new RequestData(
+            new HeadersContainer().addHeader('header2', 'val2'),
+            'POST',
+            '/url2',
+            { body: 1 }
+          ));
+          assert.strictEqual(xhr.status, 201, 'received 2nd response');
         });
-      } finally {
-        delete MockXhr.onSend;
-      }
+      });
     });
   });
 
-  describe('Mock responses', () => {
+  describe('MockXhrResponseReceiver interface', () => {
     it('getRequestBodySize() should return the body size', () => {
       const xhr = new MockXhr();
+      const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
       xhr.open('POST', '/url');
       xhr.send('body');
 
-      assert.strictEqual(xhr.getRequestBodySize(), 4);
+      return done.then((request) => {
+        assert.strictEqual(request.getRequestBodySize(), 4);
+      });
     });
 
-    it('uploadProgress() should fire upload progress events', () => {
-      const xhr = new MockXhr();
-      xhr.open('POST', '/url');
-      const events = recordEvents(xhr);
-      xhr.send('body');
+    describe('uploadProgress()', () => {
+      it('should fire upload progress events', () => {
+        const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('POST', '/url');
+        const events = recordEvents(xhr); // Add listeners BEFORE send()
+        xhr.send('body');
 
-      xhr.uploadProgress(2);
-      xhr.uploadProgress(3);
+        return done.then((request) => {
+          request.uploadProgress(2);
+          request.uploadProgress(3);
+          assert.deepEqual(events, [
+            'loadstart(0,0,false)',
+            'upload.loadstart(0,4,true)',
+            'upload.progress(2,4,true)',
+            'upload.progress(3,4,true)',
+          ], 'fired events');
+        });
+      });
 
-      assert.deepEqual(events, [
-        'loadstart(0,0,false)',
-        'upload.loadstart(0,4,true)',
-        'upload.progress(2,4,true)',
-        'upload.progress(3,4,true)',
-      ], 'fired events');
+      it('should not fire upload progress events if the upload listener flag is unset', () => {
+        const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('POST', '/url');
+        xhr.send('body');
+
+        // Add listeners AFTER send()
+        const events = recordEvents(xhr);
+
+        return done.then((request) => {
+          request.uploadProgress(2);
+          assert.deepEqual(events, [], 'no fired events');
+        });
+      });
     });
 
-    it('uploadProgress() should not fire upload progress events if the upload listener flag is unset', () => {
-      const xhr = new MockXhr();
-      xhr.open('POST', '/url');
-      xhr.send('body');
+    describe('respond()', () => {
+      it('should set response headers and body', () => {
+        const xhr = new MockXhr();
+        const status = 201;
+        const headers = { test: 'ok' };
+        const responseBody = 'response';
+        const statusText = 'all good!';
 
-      // Add listeners AFTER the send() call
-      const events = recordEvents(xhr);
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('GET', '/url');
+        xhr.send();
 
-      xhr.uploadProgress(2);
+        return done.then((request) => {
+          const events = recordEvents(xhr);
+          request.respond(status, headers, responseBody, statusText);
 
-      assert.deepEqual(events, [], 'no fired events');
+          assert.deepEqual(xhr.getResponseHeadersHash(), headers, 'Response headers');
+          assert.strictEqual(xhr.status, status, 'xhr.status');
+          assert.strictEqual(xhr.statusText, statusText, 'xhr.statusText');
+          assert.strictEqual(xhr.response, responseBody, 'xhr.response');
+          assert.strictEqual(xhr.responseText, responseBody, 'xhr.responseText');
+          assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
+          assert.deepEqual(events, [
+            // setResponseHeaders()
+            'readystatechange(2)',
+            // setResponseBody()
+            'readystatechange(3)',
+            'progress(8,8,true)',
+            'readystatechange(4)',
+            'load(8,8,true)',
+            'loadend(8,8,true)',
+          ], 'fired events');
+        });
+      });
     });
 
-    it('respond() should set response state, headers and body', () => {
-      const xhr = new MockXhr();
-      xhr.open('GET', '/url');
-      xhr.send();
-      const responseBody = 'response';
+    describe('setResponseHeaders()', () => {
+      it('should set response state and headers', () => {
+        const xhr = new MockXhr();
+        const statusText = 'Custom Created';
 
-      xhr.respond(201, { 'R-Header': '123' }, responseBody);
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('GET', '/url');
+        xhr.send();
 
-      assert.strictEqual(xhr.getAllResponseHeaders(), 'r-header: 123\r\n', 'Response headers');
-      assert.strictEqual(xhr.status, 201, 'xhr.status');
-      assert.strictEqual(xhr.statusText, 'Created', 'xhr.statusText');
-      assert.strictEqual(xhr.response, responseBody, 'xhr.response');
-      assert.strictEqual(xhr.responseText, responseBody, 'xhr.responseText');
-      assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
+        return done.then((request) => {
+          const events = recordEvents(xhr);
+          request.setResponseHeaders(201, { 'R-Header': '123' }, statusText);
+
+          assert.strictEqual(xhr.getAllResponseHeaders(), 'r-header: 123\r\n', 'Response headers');
+          assert.strictEqual(xhr.status, 201, 'xhr.status');
+          assert.strictEqual(xhr.statusText, statusText, 'xhr.statusText');
+          assert.strictEqual(xhr.readyState, MockXhr.HEADERS_RECEIVED, 'readyState HEADERS_RECEIVED');
+          assert.strictEqual(xhr.response, '', 'no response yet');
+          assert.strictEqual(xhr.responseText, '', 'no response yet');
+          assert.strictEqual(xhr.readyState, MockXhr.HEADERS_RECEIVED, 'readyState HEADERS_RECEIVED');
+          assert.deepEqual(events, ['readystatechange(2)'], 'fired event');
+        });
+      });
+
+      it('should fire upload progress events for non-empty body', () => {
+        const xhr = new MockXhr();
+
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('POST', '/url');
+
+        // Must add an upload listener before send() for upload progress events to fire
+        const events = recordEvents(xhr);
+        xhr.send('body');
+
+        return done.then((request) => {
+          request.setResponseHeaders();
+          assert.deepEqual(events, [
+            // send()
+            'loadstart(0,0,false)',
+            'upload.loadstart(0,4,true)',
+            // setResponseHeaders()
+            'upload.progress(4,4,true)',
+            'upload.load(4,4,true)',
+            'upload.loadend(4,4,true)',
+            'readystatechange(2)',
+          ], 'fired events');
+        });
+      });
     });
 
-    it('respond() should fire upload progress events', () => {
-      const xhr = new MockXhr();
-      xhr.open('POST', '/url');
-      const events = recordEvents(xhr);
-      xhr.send('body');
+    describe('downloadProgress()', () => {
+      it('should provide download progress events', () => {
+        const xhr = new MockXhr();
+        xhr.open('GET', '/url');
 
-      xhr.respond();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.send();
 
-      assert.deepEqual(events, [
-        'loadstart(0,0,false)',
-        'upload.loadstart(0,4,true)',
-        // respond() events - headers
-        'upload.progress(4,4,true)',
-        'upload.load(4,4,true)',
-        'upload.loadend(4,4,true)',
-        'readystatechange(2)',
-        // respond() events - end of body
-        'readystatechange(3)',
-        'progress(0,0,false)',
-        'readystatechange(4)',
-        'load(0,0,false)',
-        'loadend(0,0,false)',
-      ], 'fired events');
+        return done.then((request) => {
+          request.setResponseHeaders();
+          const events = recordEvents(xhr);
+          request.downloadProgress(2, 8);
+          request.downloadProgress(4, 8);
+
+          assert.strictEqual(xhr.readyState, MockXhr.LOADING, 'readyState LOADING');
+          assert.deepEqual(events, [
+            // downloadProgress()
+            'readystatechange(3)',
+            'progress(2,8,true)',
+            // downloadProgress()
+            'readystatechange(3)',
+            'progress(4,8,true)',
+          ], 'fired events');
+        });
+      });
     });
 
-    it('respond() should set response state, headers and body', () => {
-      const xhr = new MockXhr();
-      xhr.open('GET', '/url');
-      xhr.send();
-      const responseBody = 'response';
+    describe('setResponseBody()', () => {
+      it('should set response body and default headers', () => {
+        const xhr = new MockXhr();
+        const responseBody = 'response';
 
-      xhr.respond(201, { 'R-Header': '123' }, responseBody);
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('GET', '/url');
+        xhr.send();
 
-      assert.strictEqual(xhr.getAllResponseHeaders(), 'r-header: 123\r\n', 'Response headers');
-      assert.strictEqual(xhr.status, 201, 'xhr.status');
-      assert.strictEqual(xhr.statusText, 'Created', 'xhr.statusText');
-      assert.strictEqual(xhr.response, responseBody, 'xhr.response');
-      assert.strictEqual(xhr.responseText, responseBody, 'xhr.responseText');
-      assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
-    });
+        return done.then((request) => {
+          const events = recordEvents(xhr);
+          request.setResponseBody(responseBody);
 
-    it('respond() should not fire upload progress events if the upload listener flag is unset', () => {
-      const xhr = new MockXhr();
-      xhr.open('POST', '/url');
-      xhr.send('body');
+          assert.strictEqual(xhr.getAllResponseHeaders(), '', 'Response headers');
+          assert.strictEqual(xhr.status, 200, 'xhr.status');
+          assert.strictEqual(xhr.statusText, 'OK', 'xhr.statusText');
+          assert.strictEqual(xhr.response, responseBody, 'xhr.response');
+          assert.strictEqual(xhr.responseText, responseBody, 'xhr.responseText');
+          assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
+          assert.deepEqual(events, [
+            // automatic call to setResponseHeaders()
+            'readystatechange(2)',
+            // respond() events - end of body
+            'readystatechange(3)',
+            'progress(8,8,true)',
+            'readystatechange(4)',
+            'load(8,8,true)',
+            'loadend(8,8,true)',
+          ], 'fired events');
+        });
+      });
 
-      // Add listeners AFTER the send() call
-      const events = recordEvents(xhr);
+      it('should set response body if called after setResponseHeaders()', () => {
+        const xhr = new MockXhr();
+        const responseBody = 'response';
 
-      xhr.respond();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('GET', '/url');
+        xhr.send();
 
-      assert.deepEqual(events, [
-        'readystatechange(2)',
-        // respond() events - end of body
-        'readystatechange(3)',
-        'progress(0,0,false)',
-        'readystatechange(4)',
-        'load(0,0,false)',
-        'loadend(0,0,false)',
-      ], 'fired events');
-    });
+        return done.then((request) => {
+          request.setResponseHeaders();
+          const events = recordEvents(xhr);
+          request.setResponseBody(responseBody);
 
-    it('respond() with response body should fire progress events', () => {
-      const xhr = new MockXhr();
-      xhr.open('POST', '/url');
-      xhr.send('body');
-      const events = recordEvents(xhr);
-
-      xhr.respond(200, null, 'response');
-
-      assert.deepEqual(events, [
-        'readystatechange(2)',
-        // respond() events - end of body
-        'readystatechange(3)',
-        'progress(8,8,true)',
-        'readystatechange(4)',
-        'load(8,8,true)',
-        'loadend(8,8,true)',
-      ], 'fired events');
-    });
-
-    it('respond() with send(null) should not fire upload progress events', () => {
-      const xhr = new MockXhr();
-      xhr.open('GET', '/url');
-      const events = recordEvents(xhr);
-      xhr.send();
-
-      xhr.respond();
-
-      assert.deepEqual(events, [
-        'loadstart(0,0,false)',
-        // respond() events - headers
-        'readystatechange(2)',
-        // respond() events - end of body
-        'readystatechange(3)',
-        'progress(0,0,false)',
-        'readystatechange(4)',
-        'load(0,0,false)',
-        'loadend(0,0,false)',
-      ], 'fired events');
-    });
-
-    it('setResponseHeaders() should set response state and headers', () => {
-      const xhr = new MockXhr();
-      xhr.open('GET', '/url');
-      xhr.send();
-      const statusText = 'Custom Created';
-
-      xhr.setResponseHeaders(201, { 'R-Header': '123' }, statusText);
-
-      assert.strictEqual(xhr.getAllResponseHeaders(), 'r-header: 123\r\n', 'Response headers');
-      assert.strictEqual(xhr.status, 201, 'xhr.status');
-      assert.strictEqual(xhr.statusText, statusText, 'xhr.statusText');
-      assert.strictEqual(xhr.readyState, MockXhr.HEADERS_RECEIVED, 'readyState HEADERS_RECEIVED');
-      assert.strictEqual(xhr.response, '', 'no response yet');
-      assert.strictEqual(xhr.responseText, '', 'no response yet');
-      assert.strictEqual(xhr.readyState, MockXhr.HEADERS_RECEIVED, 'readyState HEADERS_RECEIVED');
-    });
-
-    it('setResponseHeaders() should fire readystatechange', () => {
-      const xhr = new MockXhr();
-      xhr.open('GET', '/url');
-      xhr.send();
-      const events = recordEvents(xhr);
-
-      xhr.setResponseHeaders();
-
-      assert.deepEqual(events, ['readystatechange(2)'], 'fired event');
-    });
-
-    it('downloadProgress() should provide download progress events', () => {
-      const xhr = new MockXhr();
-      xhr.open('GET', '/url');
-      xhr.send();
-      xhr.setResponseHeaders();
-      const events = recordEvents(xhr);
-
-      xhr.downloadProgress(2, 8);
-      xhr.downloadProgress(4, 8);
-
-      assert.deepEqual(events, [
-        // downloadProgress()
-        'readystatechange(3)',
-        'progress(2,8,true)',
-        // downloadProgress()
-        'readystatechange(3)',
-        'progress(4,8,true)',
-      ], 'fired events');
-      assert.strictEqual(xhr.readyState, MockXhr.LOADING, 'readyState LOADING');
-    });
-
-    it('setResponseBody() should set response state, headers and body', () => {
-      const xhr = new MockXhr();
-      xhr.open('GET', '/url');
-      xhr.send();
-      const responseBody = 'response';
-
-      xhr.setResponseBody(responseBody);
-
-      assert.strictEqual(xhr.getAllResponseHeaders(), '', 'Response headers');
-      assert.strictEqual(xhr.status, 200, 'xhr.status');
-      assert.strictEqual(xhr.statusText, 'OK', 'xhr.statusText');
-      assert.strictEqual(xhr.response, responseBody, 'xhr.response');
-      assert.strictEqual(xhr.responseText, responseBody, 'xhr.responseText');
-      assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
-    });
-
-    it('setResponseBody() should fire progress events', () => {
-      const xhr = new MockXhr();
-      xhr.open('GET', '/url');
-      xhr.send();
-      const responseBody = 'response';
-      const events = recordEvents(xhr);
-
-      xhr.setResponseBody(responseBody);
-
-      assert.deepEqual(events, [
-        // automatic call to setResponseHeaders()
-        'readystatechange(2)',
-        // respond() events - end of body
-        'readystatechange(3)',
-        'progress(8,8,true)',
-        'readystatechange(4)',
-        'load(8,8,true)',
-        'loadend(8,8,true)',
-      ], 'fired events');
+          assert.strictEqual(xhr.response, responseBody, 'xhr.response');
+          assert.strictEqual(xhr.responseText, responseBody, 'xhr.responseText');
+          assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
+          assert.deepEqual(events, [
+            'readystatechange(3)',
+            'progress(8,8,true)',
+            'readystatechange(4)',
+            'load(8,8,true)',
+            'loadend(8,8,true)',
+          ], 'fired events');
+        });
+      });
     });
 
     describe('setNetworkError()', () => {
-      it('should reset state', () => {
+      it('should error the request', () => {
         const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('GET', '/url');
         xhr.send();
 
-        xhr.setNetworkError();
+        return done.then((request) => {
+          const events = recordEvents(xhr);
+          request.setNetworkError();
 
-        assertNetworkErrorResponse(xhr);
-        assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
+          assertNetworkErrorResponse(xhr);
+          assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
+          assert.deepEqual(events, [
+            'readystatechange(4)',
+            'error(0,0,false)',
+            'loadend(0,0,false)',
+          ], 'fired events');
+        });
       });
 
-      it('with request body should fire upload events', () => {
+      it('should error the request after setResponseHeaders()', () => {
         const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('GET', '/url');
+        xhr.send();
+
+        return done.then((request) => {
+          request.setResponseHeaders();
+          const events = recordEvents(xhr);
+          request.setNetworkError();
+
+          assertNetworkErrorResponse(xhr);
+          assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
+          assert.deepEqual(events, [
+            'readystatechange(4)',
+            'error(0,0,false)',
+            'loadend(0,0,false)',
+          ], 'fired events');
+        });
+      });
+
+      it('should error the request after downloadProgress()', () => {
+        const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('GET', '/url');
+        xhr.send();
+
+        return done.then((request) => {
+          request.setResponseHeaders();
+          request.downloadProgress(2, 8);
+          const events = recordEvents(xhr);
+          request.setNetworkError();
+
+          assertNetworkErrorResponse(xhr);
+          assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
+          assert.deepEqual(events, [
+            'readystatechange(4)',
+            'error(0,0,false)',
+            'loadend(0,0,false)',
+          ], 'fired events');
+        });
+      });
+
+      it('should error the request and fire upload events for non-empty body', () => {
+        const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
         xhr.open('POST', '/url');
-        const events = recordEvents(xhr);
+        const events = recordEvents(xhr); // Add listeners BEFORE send()
         xhr.send('body');
 
-        xhr.setNetworkError();
+        return done.then((request) => {
+          request.setNetworkError();
 
-        assert.deepEqual(events, [
-          'loadstart(0,0,false)',
-          'upload.loadstart(0,4,true)',
-          'readystatechange(4)',
-          'upload.error(0,0,false)',
-          'upload.loadend(0,0,false)',
-          'error(0,0,false)',
-          'loadend(0,0,false)',
-        ], 'fired events');
-      });
-
-      it('with request body should not fire upload events if the upload listener flag is unset', () => {
-        const xhr = new MockXhr();
-        xhr.open('POST', '/url');
-        xhr.send('body');
-
-        // Add listeners AFTER the send() call
-        const events = recordEvents(xhr);
-
-        xhr.setNetworkError();
-
-        assert.deepEqual(events, [
-          'readystatechange(4)',
-          'error(0,0,false)',
-          'loadend(0,0,false)',
-        ], 'fired events');
-      });
-
-      it('without request body should not fire upload events', () => {
-        const xhr = new MockXhr();
-        xhr.open('GET', '/url');
-        const events = recordEvents(xhr);
-        xhr.send();
-
-        xhr.setNetworkError();
-
-        assert.deepEqual(events, [
-          'loadstart(0,0,false)',
-          'readystatechange(4)',
-          'error(0,0,false)',
-          'loadend(0,0,false)',
-        ], 'fired events');
-      });
-
-      it('should work after setResponseHeaders()', () => {
-        const xhr = new MockXhr();
-        xhr.open('GET', '/url');
-        xhr.send();
-        const events = recordEvents(xhr);
-        xhr.setResponseHeaders();
-
-        xhr.setNetworkError();
-
-        assert.deepEqual(events, [
-          'readystatechange(2)',
-          'readystatechange(4)',
-          'error(0,0,false)',
-          'loadend(0,0,false)',
-        ], 'fired events');
+          assertNetworkErrorResponse(xhr);
+          assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
+          assert.deepEqual(events, [
+            'loadstart(0,0,false)',
+            'upload.loadstart(0,4,true)',
+            'readystatechange(4)',
+            'upload.error(0,0,false)',
+            'upload.loadend(0,0,false)',
+            'error(0,0,false)',
+            'loadend(0,0,false)',
+          ], 'fired events');
+        });
       });
     });
 
     describe('setRequestTimeout()', () => {
-      describe('during request', () => {
-        it('should reset state', () => {
-          const xhr = new MockXhr();
-          xhr.open('GET', '/url');
-          xhr.send();
+      it('should time out the request', () => {
+        const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('GET', '/url');
+        xhr.send();
 
-          xhr.setRequestTimeout();
+        return done.then((request) => {
+          const events = recordEvents(xhr);
+          request.setRequestTimeout();
 
           assertNetworkErrorResponse(xhr);
           assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
+          assert.deepEqual(events, [
+            'readystatechange(4)',
+            'timeout(0,0,false)',
+            'loadend(0,0,false)',
+          ], 'fired events');
         });
+      });
 
-        it('with request body should fire upload events', () => {
-          const xhr = new MockXhr();
-          xhr.open('POST', '/url');
+      it('should time out the request after setResponseHeaders()', () => {
+        const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('GET', '/url');
+        xhr.send();
+
+        return done.then((request) => {
+          request.setResponseHeaders();
           const events = recordEvents(xhr);
-          xhr.send('body');
+          request.setRequestTimeout();
 
-          xhr.setRequestTimeout();
+          assertNetworkErrorResponse(xhr);
+          assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
+          assert.deepEqual(events, [
+            'readystatechange(4)',
+            'timeout(0,0,false)',
+            'loadend(0,0,false)',
+          ], 'fired events');
+        });
+      });
 
+      it('should time out the request after downloadProgress()', () => {
+        const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('GET', '/url');
+        xhr.send();
+
+        return done.then((request) => {
+          request.setResponseHeaders();
+          request.downloadProgress(2, 8);
+          const events = recordEvents(xhr);
+          request.setRequestTimeout();
+
+          assertNetworkErrorResponse(xhr);
+          assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
+          assert.deepEqual(events, [
+            'readystatechange(4)',
+            'timeout(0,0,false)',
+            'loadend(0,0,false)',
+          ], 'fired events');
+        });
+      });
+
+      it('should time out the request and fire upload events for non-empty body', () => {
+        const xhr = new MockXhr();
+        const done: Promise<MockXhrRequest> = new Promise((resolve) => { xhr.onSend = resolve; });
+        xhr.open('POST', '/url');
+        const events = recordEvents(xhr); // Add listeners BEFORE send()
+        xhr.send('body');
+
+        return done.then((request) => {
+          request.setRequestTimeout();
+
+          assertNetworkErrorResponse(xhr);
+          assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
           assert.deepEqual(events, [
             'loadstart(0,0,false)',
             'upload.loadstart(0,4,true)',
             'readystatechange(4)',
             'upload.timeout(0,0,false)',
             'upload.loadend(0,0,false)',
-            'timeout(0,0,false)',
-            'loadend(0,0,false)',
-          ], 'fired events');
-        });
-
-        it('with request body should not fire upload events if the upload listener flag is unset', () => {
-          const xhr = new MockXhr();
-          xhr.open('POST', '/url');
-          xhr.send('body');
-
-          // Add listeners AFTER the send() call
-          const events = recordEvents(xhr);
-
-          xhr.setRequestTimeout();
-
-          assert.deepEqual(events, [
-            'readystatechange(4)',
-            'timeout(0,0,false)',
-            'loadend(0,0,false)',
-          ], 'fired events');
-        });
-
-        it('without request body should not fire upload events', () => {
-          const xhr = new MockXhr();
-          xhr.open('GET', '/url');
-          const events = recordEvents(xhr);
-          xhr.send();
-
-          xhr.setRequestTimeout();
-
-          assert.deepEqual(events, [
-            'loadstart(0,0,false)',
-            'readystatechange(4)',
-            'timeout(0,0,false)',
-            'loadend(0,0,false)',
-          ], 'fired events');
-        });
-
-        it('should work after setResponseHeaders()', () => {
-          const xhr = new MockXhr();
-          xhr.open('GET', '/url');
-          xhr.send();
-          const events = recordEvents(xhr);
-          xhr.setResponseHeaders();
-
-          xhr.setRequestTimeout();
-
-          assert.deepEqual(events, [
-            'readystatechange(2)',
-            'readystatechange(4)',
-            'timeout(0,0,false)',
-            'loadend(0,0,false)',
-          ], 'fired events');
-        });
-      });
-
-      describe('during response', () => {
-        it('should reset state', () => {
-          const xhr = new MockXhr();
-          xhr.open('GET', '/url');
-          xhr.send();
-          xhr.setResponseHeaders();
-
-          xhr.setRequestTimeout();
-
-          assertNetworkErrorResponse(xhr);
-          assert.strictEqual(xhr.readyState, MockXhr.DONE, 'readyState DONE');
-        });
-
-        it('should fire timeout event', () => {
-          const xhr = new MockXhr();
-          xhr.open('POST', '/url');
-          xhr.send('body');
-          xhr.setResponseHeaders();
-          const events = recordEvents(xhr);
-
-          xhr.setRequestTimeout();
-
-          assert.deepEqual(events, [
-            'readystatechange(4)',
             'timeout(0,0,false)',
             'loadend(0,0,false)',
           ], 'fired events');


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you remove or skip this template, your pull request will be closed.

PR requirements:
* Follow the contributor guidelines.
* Include tests to illustrate the problem this PR resolves.
* Update the documentation where necessary.

Please place an x (no spaces - [x]) in all [ ] that apply.
-->

**This PR contains:**
- [x] bugfix
- [x] feature
- [x] refactor
- [x] documentation
- [ ] other

**Are tests included?**
- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

**Breaking Changes?**
- [x] yes (_breaking changes will not be merged unless necessary_)
- [ ] no

**Related issue numbers:**
fixes #30 
<!--
If this PR resolves any issues, list them as

  resolves #123

where 123 is the issue number. GitHub automatically handles closing the linked issue once the PR is merged.
-->

**Description**
<!-- A clear and consice description of the problem being solved. -->
Adds MockXhrRequest to encapsulate MockXhr requests. This captures the state of the `XMLHttpRequest` as it was when `send()` is called.