### PR TITLE
Add check on setRequestTimeout()

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,8 @@ Simulates a request timeout. Changes the request's `readyState` to `DONE`.
 
 Fires the appropriate events including the `timeout` event.
 
+Throws an error if the `request` attribute is equal to 0 since timeouts do not occur in that case.
+
 After you call this method, you can't use other mock response methods. This restriction is lifted if you call `open()` again.
 
 ### newMockXhr()

--- a/src/MockXhr.ts
+++ b/src/MockXhr.ts
@@ -311,7 +311,7 @@ export default class MockXhr
   setRequestTimeout(request: RequestData) {
     // Only act if the originating request is the current active request
     if (this._currentRequest?.requestData === request) {
-      if (!this._sendFlag) {
+      if (!this._sendFlag || this.timeout === 0) {
         throw new Error('Mock usage error detected.');
       }
       this._terminateRequest();


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you remove or skip this template, your pull request will be closed.

PR requirements:
* Follow the contributor guidelines.
* Include tests to illustrate the problem this PR resolves.
* Update the documentation where necessary.

Please place an x (no spaces - [x]) in all [ ] that apply.
-->

**This PR contains:**
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

**Are tests included?**
- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

**Breaking Changes?**
- [x] yes (_breaking changes will not be merged unless necessary_)
- [ ] no

**Related issue numbers:**

<!--
If this PR resolves any issues, list them as

  resolves #123

where 123 is the issue number. GitHub automatically handles closing the linked issue once the PR is merged.
-->

**Description**
<!-- A clear and consice description of the problem being solved. -->
`setRequestTimeout()` could be used even it the `timeout` attribute is set to 0. The real `XMLHttpRequest` would never produce a timeout in those conditions. This PR fixes this to prevent wrong timeouts.